### PR TITLE
Configurable overlay position

### DIFF
--- a/src/main/java/io/grayray75/fabric/fpsdisplay/config/FpsDisplayConfig.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/config/FpsDisplayConfig.java
@@ -17,5 +17,9 @@ public class FpsDisplayConfig implements ConfigData {
     @ConfigEntry.BoundedDiscrete(min = 0, max = 255)
     public int textAlpha = 230;
 
+    public int offsetTop = 2;
+
+    public int offsetLeft = 2;
+
     public boolean holdKeyToShowFps = false;
 }

--- a/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
@@ -22,8 +22,8 @@ public class InGameHudMixin {
         if (!client.options.debugEnabled && config.enabled && config.textAlpha > 3 && FpsDisplayMod.SHOW_FPS_OVERLAY) {
 
             String displayString = ((MinecraftClientMixin) client).getCurrentFPS() + " FPS";
-            float textPosX = 2;
-            float textPosY = 2;
+            float textPosX = config.offsetLeft;
+            float textPosY = config.offsetTop;
             int textColor = ((config.textAlpha & 0xFF) << 24) | config.textColor;
 
             if (config.drawWithShadows) {

--- a/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
@@ -22,8 +22,9 @@ public class InGameHudMixin {
         if (!client.options.debugEnabled && config.enabled && config.textAlpha > 3 && FpsDisplayMod.SHOW_FPS_OVERLAY) {
 
             String displayString = ((MinecraftClientMixin) client).getCurrentFPS() + " FPS";
-            float textPosX = config.offsetLeft;
-            float textPosY = config.offsetTop;
+            int guiScale = client.options.guiScale;
+            float textPosX = config.offsetLeft / guiScale;
+            float textPosY = config.offsetTop / guiScale;
             int textColor = ((config.textAlpha & 0xFF) << 24) | config.textColor;
 
             if (config.drawWithShadows) {

--- a/src/main/resources/assets/fpsdisplay/lang/de_de.json
+++ b/src/main/resources/assets/fpsdisplay/lang/de_de.json
@@ -4,6 +4,8 @@
     "text.autoconfig.fpsdisplay.option.drawWithShadows": "Textschatten",
     "text.autoconfig.fpsdisplay.option.textColor": "Text Farbe",
     "text.autoconfig.fpsdisplay.option.textAlpha": "Text Sichtbarkeit",
+    "text.autoconfig.fpsdisplay.option.offsetTop": "Abstand von oben",
+    "text.autoconfig.fpsdisplay.option.offsetLeft": "Abstand von links",
     "key.fpsdisplay.category": "FPS-Display",
     "key.fpsdisplay.toggleFpsOverlay": "FPS overlay umschalten"
 }

--- a/src/main/resources/assets/fpsdisplay/lang/en_us.json
+++ b/src/main/resources/assets/fpsdisplay/lang/en_us.json
@@ -4,6 +4,8 @@
     "text.autoconfig.fpsdisplay.option.drawWithShadows": "Text shadows",
     "text.autoconfig.fpsdisplay.option.textColor": "Text color",
     "text.autoconfig.fpsdisplay.option.textAlpha": "Text visibility",
+    "text.autoconfig.fpsdisplay.option.offsetTop": "Top offset",
+    "text.autoconfig.fpsdisplay.option.offsetLeft": "Left offset",
     "text.autoconfig.fpsdisplay.option.holdKeyToShowFps": "'Hold key to show fps' Mode",
     "key.fpsdisplay.category": "FPS-Display",
     "key.fpsdisplay.toggleFpsOverlay": "Toggle FPS overlay"


### PR DESCRIPTION
Hi Grayray75,

I really like the simplicity of your mod. But it was interfering with other mods (e.g. "BiomeInfo") because both render at the top left.

So I added an option to configure the position of the FPS display overlay. I built & tested it and it works like a charm. I also took care of handling the current GUI scale.

Actually I first tried it with a Slider 0-100% (using `@ConfigEntry.BoundedDiscrete(min = 0, max = 100)`). But as I couldn't find a way to determine current GUI resolution I just left it as a normal input field (to specify the pixel position). Maybe you know a way?

Anyway, I hope you'll like my addition.