### PR TITLE
Set default overlay position in FPSDisplayConfig class

### DIFF
--- a/src/main/java/io/grayray75/fabric/fpsdisplay/config/FpsDisplayConfig.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/config/FpsDisplayConfig.java
@@ -18,10 +18,10 @@ public class FpsDisplayConfig implements ConfigData {
     public int textAlpha = 230;
 
     @ConfigEntry.BoundedDiscrete(min = 0, max = 200)
-    public int verticalPosition = 0;
+    public int verticalPosition = 2;
 
     @ConfigEntry.BoundedDiscrete(min = 0, max = 200)
-    public int horizontalPosition = 0;
+    public int horizontalPosition = 2;
 
     public boolean holdKeyToShowFps = false;
 }

--- a/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
@@ -21,8 +21,8 @@ public class InGameHudMixin {
         if (!client.options.debugEnabled && config.enabled && config.textAlpha > 3 && FpsDisplayMod.SHOW_FPS_OVERLAY) {
 
             String displayString = ((MinecraftClientMixin) client).getCurrentFPS() + " FPS";
-            float textPosX = ((client.getWindow().getScaledWidth() - client.textRenderer.getWidth(displayString) - 2)) * ((float) config.horizontalPosition / 200f) + 2;
-            float textPosY = ((client.getWindow().getScaledHeight() - client.textRenderer.fontHeight) - 2) * ((float) config.verticalPosition / 200f) + 2;
+            float textPosX = (client.getWindow().getScaledWidth() - client.textRenderer.getWidth(displayString)) * ((float) config.horizontalPosition / 200f);
+            float textPosY = (client.getWindow().getScaledHeight() - client.textRenderer.fontHeight) * ((float) config.verticalPosition / 200f);
             int textColor = ((config.textAlpha & 0xFF) << 24) | config.textColor;
 
             if (config.drawWithShadows) {


### PR DESCRIPTION
Hi again,

I find it a bit complicated and unnecessary to try and incorporate the default overlay position of (x=2,y=2) into the formula.

So I moved this into the FpsDisplayConfig class instead (which makes more sense I think, i.a. because other configuration options like `textAlpha` have their default value there, too).

Or did you have some other goal while going this approach?