### PR TITLE
Prevent the FPS display overlay to render outside of the screen

### DIFF
--- a/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
+++ b/src/main/java/io/grayray75/fabric/fpsdisplay/mixin/InGameHudMixin.java
@@ -30,6 +30,12 @@ public class InGameHudMixin {
                 textPosY /= guiScale;
             }
 
+            // Prevent FPS-Display to render outside screenspace
+            float maxTextPosX = client.getWindow().getScaledWidth() - client.textRenderer.getWidth(displayString);
+            float maxTextPosY = client.getWindow().getScaledHeight() - client.textRenderer.fontHeight;
+            textPosX = Math.min(textPosX, maxTextPosX);
+            textPosY = Math.min(textPosY, maxTextPosY);
+
             int textColor = ((config.textAlpha & 0xFF) << 24) | config.textColor;
 
             if (config.drawWithShadows) {


### PR DESCRIPTION
I see you have already implemented what I also tried to accomplish (see also my comment in 75bbc42fea72a7754631a2002c09c0af2a41c8f8).

I want to go one step further and prevent that the FPS display overlay gets rendered outside of the screen.
At first the maximum possible position where the overlay would still be fully visible is calculated. Then the lower value of this and the configured position/offset is taken.